### PR TITLE
Update getAll method for Message service to allow other parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea/

--- a/src/FlexmailAPI/Service/FlexmailAPI_Message.php
+++ b/src/FlexmailAPI/Service/FlexmailAPI_Message.php
@@ -85,23 +85,25 @@ class FlexmailAPI_Message extends FlexmailAPI implements FlexmailAPIServiceInter
   }
 
   /**
-   * Get all Messages
-   *
-   * @param Array $parameters Associative array with archivedMessages property.
-   *
-   * @return messageTypeItems array
-   */
+  * Get all Messages
+  *
+  * Parmeters example:
+  * ------------------
+  * $parameters = array (
+  *      "archived"     => true, // bool optional
+  *      "metaDataOnly" => true, // bool optional
+  *      "optin"        => true, // bool optional
+  * );
+  *
+  * @param Array $parameters Associative array with archived,
+  *                          metaDataOnly and optin booleans
+  *
+  * @return messageTypeItems array
+  */
   public function getAll($parameters = NULL) {
-    $request = NULL;
-
-    if (isset($parameters) && (array_key_exists("archivedMessages", $parameters) && ($parameters["archivedMessages"]))):
-
-      $request = FlexmailAPI::parseArray($parameters);
-
-    endif;
+    $request = FlexmailAPI::parseArray($parameters);
 
     $response = $this->execute("GetMessages", $request);
-
     return FlexmailAPI::stripHeader($response, $this->config->get('debug_mode'));
   }
 }

--- a/src/FlexmailAPI/Service/FlexmailAPI_Message.php
+++ b/src/FlexmailAPI/Service/FlexmailAPI_Message.php
@@ -101,7 +101,11 @@ class FlexmailAPI_Message extends FlexmailAPI implements FlexmailAPIServiceInter
   * @return messageTypeItems array
   */
   public function getAll($parameters = NULL) {
-    $request = FlexmailAPI::parseArray($parameters);
+    $request = NULL;
+
+    if (is_array($parameters)) {
+      $request = FlexmailAPI::parseArray($parameters);
+    }
 
     $response = $this->execute("GetMessages", $request);
     return FlexmailAPI::stripHeader($response, $this->config->get('debug_mode'));


### PR DESCRIPTION
This is my first fork/pull request so I hope I'm doing this right :)

The Flexmail API apparently has had some changes the last couple of months. Did some minor updates in the getAll method of the Message service to allow using other parameters.
